### PR TITLE
Update innova_device.py

### DIFF
--- a/innova_controls/innova_device.py
+++ b/innova_controls/innova_device.py
@@ -89,7 +89,7 @@ class InnovaDevice(ABC):
 
     @property
     def keyboard_locked(self) -> bool:
-        if "ps" in self._status:
+        if "kl" in self._status:
             return self._status["kl"] == 1
         return False
 

--- a/innova_controls/innova_device.py
+++ b/innova_controls/innova_device.py
@@ -89,6 +89,8 @@ class InnovaDevice(ABC):
 
     @property
     def keyboard_locked(self) -> bool:
+        if "ps" in self._status:
+            return self._status["kl"] == 1
         return False
 
     @abstractmethod


### PR DESCRIPTION
Fix keyboard_locked property to reflect device state
The previous implementation always returned False.
This fix uses _status["kl"] == 1 when "kl" is present in _status.